### PR TITLE
Disable auth through command line flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,16 +34,18 @@ func main() {
 	flag.StringVar(&dst, "dst", "", "Destination end-point, either AgentName or AgentName:LFN")
 	var register string
 	flag.StringVar(&register, "register", "", "File with meta-data of records in JSON data format to register at remote agent")
-	
-	var auth bool
-	flag.BoolVar(&auth, "auth", true, "To disable the auth layer")
-	
+
+	var authVar bool
+	flag.BoolVar(&authVar, "auth", true, "To disable the auth layer")
+
 	flag.Parse()
-	
-	if auth {
+
+	if authVar {
 		utils.CheckX509()
 	}
-	
+
+	server.Initialize(authVar)
+
 	utils.VERBOSE = verbose
 	if configFile != "" {
 		data, err := ioutil.ReadFile(configFile)
@@ -83,9 +85,7 @@ func main() {
 		if config.Register == "" {
 			log.Println("WARNING this agent is not registered with remote ones, either provide register in your config or invoke register API call")
 		}
-		
-		config.Auth = auth
-		
+
 		server.Server(config)
 	} else {
 		var err error

--- a/main.go
+++ b/main.go
@@ -34,9 +34,16 @@ func main() {
 	flag.StringVar(&dst, "dst", "", "Destination end-point, either AgentName or AgentName:LFN")
 	var register string
 	flag.StringVar(&register, "register", "", "File with meta-data of records in JSON data format to register at remote agent")
-
+	
+	var auth bool
+	flag.Bool(&auth, "auth", true, "To disable the auth layer")
+	
 	flag.Parse()
-	utils.CheckX509()
+	
+	if auth {
+		utils.CheckX509()
+	}
+	
 	utils.VERBOSE = verbose
 	if configFile != "" {
 		data, err := ioutil.ReadFile(configFile)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.StringVar(&register, "register", "", "File with meta-data of records in JSON data format to register at remote agent")
 	
 	var auth bool
-	flag.Bool(&auth, "auth", true, "To disable the auth layer")
+	flag.BoolVar(&auth, "auth", true, "To disable the auth layer")
 	
 	flag.Parse()
 	

--- a/main.go
+++ b/main.go
@@ -83,7 +83,9 @@ func main() {
 		if config.Register == "" {
 			log.Println("WARNING this agent is not registered with remote ones, either provide register in your config or invoke register API call")
 		}
-
+		
+		config.Auth = auth
+		
 		server.Server(config)
 	} else {
 		var err error

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -58,7 +58,9 @@ func userDNs() []string {
 }
 
 func init() {
-	_userDNs = userDNs()
+	if _config.Auth {
+		_userDNs = userDNs()
+	}
 }
 
 // custom logic for CMS authentication, users may implement their own logic here
@@ -78,7 +80,14 @@ func auth(r *http.Request) bool {
 // AuthHandler authenticate incoming requests and route them to appropriate handler
 func AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// check if server started with hkey file (auth is required)
-	status := auth(r)
+	var status bool
+	
+	if _config.Auth {
+		status = auth(r)
+	} else {
+		status = true
+	}
+	
 	if !status {
 		msg := "You are not allowed to access this resource"
 		http.Error(w, msg, http.StatusForbidden)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -22,6 +22,7 @@ import (
 
 // global variable which we initialize once
 var _userDNs []string
+var authVar bool
 
 func userDNs() []string {
 	var out []string
@@ -57,14 +58,24 @@ func userDNs() []string {
 	return out
 }
 
-func init() {
-	if _config.Auth {
+// func init() {
+// 	//	_userDNs = userDNs()
+//}
+
+func Initialize(authArg bool) {
+	authVar = authArg
+	if authVar {
 		_userDNs = userDNs()
 	}
 }
 
 // custom logic for CMS authentication, users may implement their own logic here
 func auth(r *http.Request) bool {
+
+	if !authVar {
+		return true
+	}
+
 	if utils.VERBOSE > 1 {
 		dump, err := httputil.DumpRequest(r, true)
 		log.Println("AuthHandler HTTP request", r, string(dump), err)
@@ -80,14 +91,7 @@ func auth(r *http.Request) bool {
 // AuthHandler authenticate incoming requests and route them to appropriate handler
 func AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// check if server started with hkey file (auth is required)
-	var status bool
-	
-	if _config.Auth {
-		status = auth(r)
-	} else {
-		status = true
-	}
-	
+	status := auth(r)
 	if !status {
 		msg := "You are not allowed to access this resource"
 		http.Error(w, msg, http.StatusForbidden)

--- a/server/server.go
+++ b/server/server.go
@@ -39,7 +39,6 @@ type Config struct {
 	Register  string `json:"register"`  // remote agent URL to register
 	ServerKey string `json:"serverkey"` // server key file
 	ServerCrt string `json:"servercrt"` // server crt file
-	Auth	  bool   `json:"auth"`      // disable auth layer
 }
 
 // String returns string representation of Config data type

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,7 @@ type Config struct {
 	Register  string `json:"register"`  // remote agent URL to register
 	ServerKey string `json:"serverkey"` // server key file
 	ServerCrt string `json:"servercrt"` // server crt file
+	Auth	  bool   `json:"auth"`      // disable auth layer
 }
 
 // String returns string representation of Config data type


### PR DESCRIPTION
The default value of command line auth argument is true. 
To disable the auth layer set it false.

**Example**
```
./transfer2go --auth=false
```