### PR TITLE
Add client CLI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -312,3 +312,51 @@ func readFile(path string) (string, int64, error) {
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	return hash, bytes, nil
 }
+
+
+func RegisterRequest(agent string, src string, dst string) {
+	var source string
+	// resolve source agent name/alias and identify file to transfer
+	if strings.Contains(src, ":") {
+		arr := strings.Split(src, ":")
+		source = arr[len(arr)-1]
+	}
+	// parse the input
+	var lfn, block, dataset string
+	if strings.Contains(src, "#") { // it is a block name, e.g. /a/b/c#123
+		arr := strings.Split(src, "#")
+		dataset = arr[0]
+		block = arr[1]
+	} else if strings.Count(src, "/") == 3 { // it is a dataset
+		dataset = src
+	} else { // it is lfn
+		lfn = src
+	}
+	var requests []core.TransferRequest
+	req := core.TransferRequest{SrcUrl: source, File: lfn, Block: block, Dataset: dataset, DstUrl: dst}
+	furl := agent + "/request"
+  requests = append(requests, req)
+  d, err := json.Marshal(requests)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"Agent": agent,
+			"Src":  src,
+			"Error": err,
+		}).Info("Unable to marshal request")
+		return
+	}
+	resp := utils.FetchResponse(furl, d)
+	if resp.Error != nil || resp.StatusCode != 200 {
+		log.WithFields(log.Fields{
+			"Agent": agent,
+			"Src": src,
+			"Error": resp.Error,
+		}).Info("Error while registering request to main agent")
+		return
+	}
+	log.WithFields(log.Fields{
+		"Agent": agent,
+		"Src": src,
+		"Dst": dst,
+	}).Info("successfully registered request")
+}

--- a/client/client.go
+++ b/client/client.go
@@ -324,9 +324,7 @@ func RegisterRequest(agent string, src string, dst string) {
 	// parse the input
 	var lfn, block, dataset string
 	if strings.Contains(src, "#") { // it is a block name, e.g. /a/b/c#123
-		arr := strings.Split(src, "#")
-		dataset = arr[0]
-		block = arr[1]
+		block = src
 	} else if strings.Count(src, "/") == 3 { // it is a dataset
 		dataset = src
 	} else { // it is lfn

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ func main() {
 	flag.StringVar(&dst, "dst", "", "Destination end-point, either AgentName or AgentName:LFN")
 	var register string
 	flag.StringVar(&register, "register", "", "File with meta-data of records in JSON data format to register at remote agent")
+	var request string
+	flag.StringVar(&request, "request", "", "To register new transfer request with the main agent")
 
 	var authVar bool
 	flag.BoolVar(&authVar, "auth", true, "To disable the auth layer")
@@ -102,6 +104,8 @@ func main() {
 			err = client.Register(agent, register)
 		} else if src == "" { // no transfer request
 			client.Agent(agent)
+		} else if request != "" {
+			client.RegisterRequest(request, src, dst)
 		} else {
 			err = client.Transfer(agent, src, dst)
 		}


### PR DESCRIPTION
Command to register request:
```
./transfer2go -request=http://localhost:8989 -src=http://localhost:8000:file.root -dst=http://localhost:9000 -auth=false
```

The -request flag will helpful to pass the main agent's url. Instead of modifying functions I added new function and parameter to register request. Because the current code of client can be useful in future.