### PR TITLE
Add catalog exec method to avoid db lock error

### DIFF
--- a/core/catalog.go
+++ b/core/catalog.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vkuznet/transfer2go/utils"
@@ -358,6 +359,7 @@ func (c *Catalog) Exec(stm string, status string, id int64) error {
 	for err != nil && count < 3 {
 		_, err = DB.Exec(stm, status, id)
 		count += 1
+		time.Sleep(time.Second * 1)
 	}
 	return err
 }

--- a/core/catalog.go
+++ b/core/catalog.go
@@ -351,10 +351,21 @@ func (c *Catalog) InsertRequest(request TransferRequest) error {
 	return e
 }
 
+// Try to update db upto three times
+func (c *Catalog) Exec(stm string, status string, id int64) error {
+	count := 0
+	_, err := DB.Exec(stm, status, id)
+	for err != nil && count < 3 {
+		_, err = DB.Exec(stm, status, id)
+		count += 1
+	}
+	return err
+}
+
 // UpdateRequest updates the status of request
 func (c *Catalog) UpdateRequest(id int64, status string) error {
 	stm := getSQL("update_request")
-	_, err := DB.Exec(stm, status, id)
+	err := c.Exec(stm, status, id)
 	return err
 }
 


### PR DESCRIPTION
I tried to solve this problem with busy_timeout but it is helpful when we have multiple connections with the DB. 

Reference: https://godoc.org/github.com/mxk/go-sqlite/sqlite3#Conn.BusyTimeout